### PR TITLE
Fixed: 64bit issues, encapsulation issues, memory leaks, makefile commands.

### DIFF
--- a/CDist.cpp
+++ b/CDist.cpp
@@ -42,7 +42,7 @@ bool CDist::equals(const CDist& dist, double tol) const
 #ifdef _NDLMATLAB
 mxArray* CDist::toMxArray() const
 {
-  int dims[1];
+  size_t dims[1];
   dims[0] = 1;
   const char *fieldNames[] = {"type", "transforms"};
   mxArray* matlabArray = mxCreateStructArray(1, dims, 2, fieldNames);
@@ -285,7 +285,7 @@ double CWangDist::getGradInput(double x) const
 #ifdef _NDLMATLAB
 mxArray* CParamPriors::toMxArray() const
 {
-  int dims[1];
+  size_t dims[1];
   // dists field.
   const char *transFieldNames[] = {"index", "type"};
   dims[0]=getNumDists();

--- a/CGp.cpp
+++ b/CGp.cpp
@@ -1435,7 +1435,7 @@ CGp::CGp(CMatrix* pinData,
 }
 mxArray* CGp::toMxArray() const
 {
-  int dims[1];
+  size_t dims[1];
   dims[0]=1;
   mxArray* matlabArray;
   if(isSparseApproximation()) 

--- a/CGp.h
+++ b/CGp.h
@@ -345,6 +345,9 @@ public:
   {
     backConstrained = val;
   }
+  inline const CKern* getKernel() const {
+    return pkern;
+  }
  
   CMapModel* backConstraintModel; // for mapping constraints on latent variables.
   CMatrix X_u; // for inducing variables if needed.

--- a/CIvm.cpp
+++ b/CIvm.cpp
@@ -622,7 +622,7 @@ CIvm::CIvm(CMatrix* inData,
 }
 mxArray* CIvm::toMxArray() const
 {
-  int dims[1];
+  size_t dims[1];
   dims[0]=1;
   const char* fieldNames[]={"I", "J", "m", "beta"};
   mxArray* matlabArray = mxCreateStructArray(1, dims, 4, fieldNames);

--- a/CKern.cpp
+++ b/CKern.cpp
@@ -4077,7 +4077,7 @@ void CKern::readParamsFromStream(istream& in)
 #ifdef _NDLMATLAB
 mxArray* CKern::toMxArray() const
 {
-  int dims[1];
+  size_t dims[1];
   dims[0] = 1;
   const char *fieldNames[] = {"type", "transforms", "inputDimension"};
   mxArray* matlabArray = mxCreateStructArray(1, dims, 3, fieldNames);
@@ -4228,7 +4228,7 @@ void CComponentKern::extractParamFromMxArray(const mxArray* matlabArray)
 void CComponentKern::addParamToMxArray(mxArray* matlabArray) const
 {
   // Add comp field to mxArray.
-  int dims[1];
+  size_t dims[1];
   mxAddField(matlabArray, "comp");
   dims[0] = components.size();
   mxArray* compArray = mxCreateCellArray(1, dims);

--- a/CMatrix.cpp
+++ b/CMatrix.cpp
@@ -1173,7 +1173,7 @@ void CMatrix::toUnheadedStream(ostream& out) const
 #ifdef _NDLMATLAB
 mxArray* CMatrix::toMxArray() const 
 {
-  int dims[2];
+  size_t dims[2];
   dims[0] = nrows;
   dims[1] = ncols;
   mxArray* matlabArray = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -1204,7 +1204,7 @@ void CMatrix::fromFullMxArray(const mxArray* matlabArray)
   {
     throw ndlexceptions::Error("mxArray does not have 2 dimensions.");
   }
-  const int* dims = mxGetDimensions(matlabArray);
+  const size_t* dims = mxGetDimensions(matlabArray);
   resize(dims[0], dims[1]);
   double* matlabVals = mxGetPr(matlabArray);
   dcopy_(ncols*nrows, matlabVals, 1, vals, 1);
@@ -1220,12 +1220,12 @@ void CMatrix::fromSparseMxArray(const mxArray* matlabArray)
   {
     throw ndlexceptions::Error("mxArray does not have 2 dimensions.");
   }
-  const int* dims = mxGetDimensions(matlabArray);
+  const size_t* dims = mxGetDimensions(matlabArray);
   resize(dims[0], dims[1]);
   double* matlabVals = mxGetPr(matlabArray);
   setVals(0.0);
-  int* matlabIr = mxGetIr(matlabArray);
-  int* matlabJc = mxGetJc(matlabArray);
+  size_t* matlabIr = mxGetIr(matlabArray);
+  size_t* matlabJc = mxGetJc(matlabArray);
   int nnz = matlabJc[getCols()];
   for(int j=0; j<getCols(); j++) 
   {

--- a/CNdlInterfaces.h
+++ b/CNdlInterfaces.h
@@ -244,7 +244,7 @@ class CMatInterface
   }
   mxArray* convertMxArray(const bool val) const
   {
-    int dims[1];
+    size_t dims[1];
     dims[0] = 1;
     mxArray* matlabArray = mxCreateNumericArray(1, dims, mxDOUBLE_CLASS, mxREAL);
     double* matlabVals = mxGetPr(matlabArray);
@@ -256,7 +256,7 @@ class CMatInterface
   }
   mxArray* convertMxArray(const double val) const
   {
-    int dims[1];
+    size_t dims[1];
     dims[0] = 1;
     mxArray* matlabArray = mxCreateNumericArray(1, dims, mxDOUBLE_CLASS, mxREAL);
     double* matlabVals = mxGetPr(matlabArray);
@@ -269,7 +269,7 @@ class CMatInterface
   }
   mxArray* convertMxArray(const vector<int> vals) const
   {
-    int dims[2];
+    size_t dims[2];
     dims[0]=(int)vals.size();
     dims[1] = 1;
     mxArray* matlabArray = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);
@@ -282,7 +282,7 @@ class CMatInterface
   }
   mxArray* convertMxArray(const vector<unsigned int> vals) const
   {
-    int dims[2];
+    size_t dims[2];
     dims[0]=(int)vals.size();
     dims[1] = 1;
     mxArray* matlabArray = mxCreateNumericArray(2, dims, mxDOUBLE_CLASS, mxREAL);

--- a/CNoise.cpp
+++ b/CNoise.cpp
@@ -59,7 +59,7 @@ void CNoise::updateSites(CMatrix& m, CMatrix& beta, unsigned int actIndex,
 #ifdef _NDLMATLAB
 mxArray* CNoise::toMxArray() const
 {
-  int dims[1];
+  size_t dims[1];
   dims[0] = 1;
   const char *fieldNames[] = {"type", "transforms", "numProcess", "spherical", "nParams", "missing", "logconcave"};
 

--- a/CTransform.cpp
+++ b/CTransform.cpp
@@ -158,7 +158,7 @@ bool CParamTransforms::equals(CParamTransforms transforms) const
 #ifdef _NDLMATLAB
 mxArray* CParamTransforms::toMxArray() const
 {
-  int dims[1];
+  size_t dims[1];
   // transforms field.
   const char *transFieldNames[] = {"index", "type"};
   dims[0]=getNumTransforms();

--- a/CTransform.h
+++ b/CTransform.h
@@ -172,9 +172,8 @@ class CParamTransforms : public CMatInterface, public CStreamInterface
 #endif
   void addTransform(const CTransform* trans, unsigned int index) 
   {
-    
     transIndex.push_back(index);
-    transforms.push_back(trans->clone());
+    transforms.push_back(trans);
   }
 
   void clearTransforms() 
@@ -184,13 +183,11 @@ class CParamTransforms : public CMatInterface, public CStreamInterface
   }
   inline string getTransformType(unsigned int ind) const 
   {
-    
     BOUNDCHECK(ind<getNumTransforms());
     return transforms[ind]->getType();
   }
   inline unsigned int getTransformIndex(unsigned int ind) const 
   {
-    
     BOUNDCHECK(ind<getNumTransforms());
     return transIndex[ind];
   }
@@ -198,9 +195,8 @@ class CParamTransforms : public CMatInterface, public CStreamInterface
   {
     return transforms.size();
   }
-	
 
-  vector<CTransform*> transforms;
+  vector<const CTransform*> transforms;
   vector<unsigned int> transIndex;
 };
 
@@ -339,12 +335,10 @@ class CTransformable
   }
   void addTransform(const CTransform* trans, unsigned int index) 
   {
-    
     BOUNDCHECK(index<getNumParams());
-    transArray.transIndex.push_back(index);
-    transArray.transforms.push_back(trans->clone());
+    transArray.addTransform(trans, index);
   }
-  
+
   void clearTransforms() 
   {
     for(size_t i = 0; i<transArray.transforms.size(); i++)
@@ -352,7 +346,7 @@ class CTransformable
     transArray.transIndex.clear();
     transArray.transforms.clear();
   }
-  
+
 #ifdef _NDLMATLAB
   mxArray* transformsToMxArray() const 
   {

--- a/gp.cpp
+++ b/gp.cpp
@@ -412,7 +412,7 @@ void CClgp::learn()
 #ifdef _NDLMATLAB
     // Write matlab output.
     pmodel->writeMatlabFile(modelFileName, "gpInfo");
-    pmodel->kern.updateMatlabFile(modelFileName, "kern");
+    pmodel->getKernel()->updateMatlabFile(modelFileName, "kern");
     X.updateMatlabFile(modelFileName, "X");
     y.updateMatlabFile(modelFileName, "y");
 #else 
@@ -508,7 +508,7 @@ void CClgp::relearn()
 #ifdef _NDLMATLAB
     // Write matlab output.
     pmodel->writeMatlabFile(newModelFileName, "gpInfo");
-    pmodel->kern.updateMatlabFile(newModelFileName, "kern");
+    pmodel->getKernel()->updateMatlabFile(newModelFileName, "kern");
     X.updateMatlabFile(newModelFileName, "X");
     y.updateMatlabFile(newModelFileName, "y");
 #else 

--- a/gplvm.cpp
+++ b/gplvm.cpp
@@ -600,7 +600,7 @@ void CClgplvm::learn()
 #ifdef _NDLMATLAB
     // Write matlab output.
     pmodel->writeMatlabFile(modelFileName, "gplvmInfo");
-    pmodel->kern.updateMatlabFile(modelFileName, "kern");
+    pmodel->pkern->updateMatlabFile(modelFileName, "kern");
     X.updateMatlabFile(modelFileName, "X");
     Y.updateMatlabFile(modelFileName, "Y");
 #else 

--- a/ivm.cpp
+++ b/ivm.cpp
@@ -227,8 +227,8 @@ void CClivm::relearn()
 #ifdef _NDLMATLAB
     // Write matlab output.
     model.writeMatlabFile(newModelFileName, "ivmInfo");
-    model.kern.updateMatlabFile(newModelFileName, "kern");
-    model.noise.updateMatlabFile(newModelFileName, "noise");
+    model.pkern->updateMatlabFile(newModelFileName, "kern");
+    model.pnoise->updateMatlabFile(newModelFileName, "noise");
     X.updateMatlabFile(newModelFileName, "X");
     y.updateMatlabFile(newModelFileName, "y");
 #else 
@@ -649,8 +649,8 @@ void CClivm::learn() {
 #ifdef _NDLMATLAB
     // Write matlab output.
     model.writeMatlabFile(modelFileName, "ivmInfo");
-    model.kern.updateMatlabFile(modelFileName, "kern");
-    model.noise.updateMatlabFile(modelFileName, "noise");
+    model.pkern->updateMatlabFile(modelFileName, "kern");
+    model.pnoise->updateMatlabFile(modelFileName, "noise");
     X.updateMatlabFile(modelFileName, "X");
     y.updateMatlabFile(modelFileName, "y");
 #else 

--- a/makefile
+++ b/makefile
@@ -129,10 +129,23 @@ CMatrix.o: CMatrix.cpp CMatrix.h ndlassert.h ndlexceptions.h \
   CNdlInterfaces.h ndlstrutil.h ndlutil.h ndlfortran.h lapack.h
 	$(CC) -c CMatrix.cpp -o CMatrix.o $(CCFLAGS)
 
+CGp.o: CGp.cpp CGp.h CMltools.h ndlassert.h ndlexceptions.h \
+  ndlstrutil.h COptimisable.h CMatrix.h CNdlInterfaces.h ndlutil.h \
+  ndlfortran.h lapack.h CKern.h CTransform.h CDataModel.h CDist.h \
+  CNoise.h
+	$(CC) -c CGp.cpp -o CGp.o $(CCFLAGS)
+
+CIvm.o: CIvm.cpp CIvm.h CMltools.h ndlassert.h ndlexceptions.h \
+  ndlstrutil.h COptimisable.h CMatrix.h CNdlInterfaces.h ndlutil.h \
+  ndlfortran.h lapack.h CKern.h CTransform.h CDataModel.h CDist.h \
+  CNoise.h
+	$(CC) -c CIvm.cpp -o CIvm.o $(CCFLAGS)
+
 ndlutil.o: ndlutil.cpp ndlutil.h ndlassert.h ndlexceptions.h ndlfortran.h
 	$(CC) -c ndlutil.cpp -o ndlutil.o $(CCFLAGS)
 
 ndlstrutil.o: ndlstrutil.cpp ndlstrutil.h ndlexceptions.h
+	$(CC) -c ndlstrutil.cpp -o ndlstrutil.o $(CCFLAGS)
 
 ndlassert.o: ndlassert.cpp ndlassert.h ndlexceptions.h
 	$(CC) -c ndlassert.cpp -o ndlassert.o $(CCFLAGS)


### PR DESCRIPTION
64b issues: int cannot be used for dimensions passed to mex commands on 64bit systems. size_t can and should be valid also for 32bit.
encapsulation: in release more, CKernel pkern is private in the CGp class. So I made a const getter to access it.
memory leaks: unnecessary clone()-s for CTransform.
makefile: added commands to compile objects for CGp, CIvm & ndlstrutil to give them all necessary flags.
